### PR TITLE
Use of hard-coded passwords is a bad practice 

### DIFF
--- a/hiera.yaml
+++ b/hiera.yaml
@@ -1,0 +1,6 @@
+:hierarchy:
+  - common
+:backends:
+  - yaml
+:yaml:
+:datadir: 'hieradata'

--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -1,0 +1,2 @@
+---
+db_pwd: password

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -45,7 +45,7 @@ class icinga2::params {
   #Database paramters
   $db_name = 'icinga2_data'
   $db_user = 'icinga2'
-  $db_password = 'password'
+  $db_password = hiera('db_pwd')
   $db_host = 'localhost'
 
   ##############################


### PR DESCRIPTION
Greetings, 
I am a security researcher, who is looking for security smells in Puppet scripts. 
I noticed instances of hard-coded passwords, which are against the best practices 
recommended by Common Weakness Enumeration (CWE) [https://cwe.mitre.org/data/definitions/259.html] and also by other security practitioners.
I suggest hiera support to mitigate this smell. Feedback is welcome. 

Here is where I noticed hard-coded passwords: 
https://github.com/carroarmato0/puppet-icinga2/blob/master/manifests/params.pp